### PR TITLE
Fix Windows OS identifier to match release binary

### DIFF
--- a/src/postgres_language_server.rs
+++ b/src/postgres_language_server.rs
@@ -45,7 +45,7 @@ impl PostgresLanguageServerExtension {
             os = match platform {
                 zed::Os::Mac => "apple-darwin",
                 zed::Os::Linux => "unknown-linux-gnu",
-                zed::Os::Windows => "ps-windows-msvc",
+                zed::Os::Windows => "pc-windows-msvc",
             }
         );
 


### PR DESCRIPTION
Trying to start this LSP on my windows machine errors with
```
Language server postgres-language-server:

from extension "Postgres Language Server" version 0.0.1: no asset found matching "postgrestools_x86_64-ps-windows-msvc"
```
because of the `ps` => `pc` typo.  

It is `pc-windows-msvc` in the upstream release:  
https://github.com/supabase-community/postgres-language-server/releases/tag/0.14.0  

---

I have tested installing the patched extension as a Dev Extension, and it initialized correctly and is now working.