### PR TITLE
chore: fix name in release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: huacnlee/zed-extension-action@v1
         with:
-          extension-name: postgres-lsp
+          extension-name: postgres-language-server
           # extension-path: extensions/${{ extension-name }}
           push-to: LoamStudios/zed-extensions
         env:


### PR DESCRIPTION
Updating the name was missed when I renamed the project.
