### PR TITLE
chore: accomodate renaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ extension.wasm
 # Neve commit test files
 postgrestools.jsonc
 test.sql
+.claude-session-id

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,9 +66,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "flate2"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc5a4e564e38c699f2880d3fda590bedc2e69f3f84cd48b457bd892ce61d0aa9"
+checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -409,9 +409,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e0f6df8eaa422d97d72edcd152e1451618fed47fabbdbd5a8864167b1d4aff7"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]

--- a/src/postgres_language_server.rs
+++ b/src/postgres_language_server.rs
@@ -12,12 +12,12 @@ impl PostgresLanguageServerExtension {
         language_server_id: &LanguageServerId,
         worktree: &zed::Worktree,
     ) -> Result<String> {
-        if let Some(path) = worktree.which("postgrestools") {
+        if let Some(path) = worktree.which("postgres-language-server") {
             return Ok(path);
         }
 
         if let Some(path) = &self.cached_binary_path {
-            if fs::metadata(path).map_or(false, |stat| stat.is_file()) {
+            if fs::metadata(path).is_ok_and(|stat| stat.is_file()) {
                 return Ok(path.clone());
             }
         }
@@ -36,7 +36,7 @@ impl PostgresLanguageServerExtension {
 
         let (platform, arch) = zed::current_platform();
         let asset_name = format!(
-            "postgrestools_{arch}-{os}",
+            "postgres-language-server_{arch}-{os}",
             arch = match arch {
                 zed::Architecture::Aarch64 => "aarch64",
                 zed::Architecture::X86 => "x86",
@@ -55,12 +55,12 @@ impl PostgresLanguageServerExtension {
             .find(|asset| asset.name == asset_name)
             .ok_or_else(|| format!("no asset found matching {:?}", asset_name))?;
 
-        let version_dir = format!("postgrestools-{}", release.version);
+        let version_dir = format!("postgres-language-server-{}", release.version);
         fs::create_dir_all(&version_dir)
             .map_err(|err| format!("failed to create directory '{version_dir}': {err}"))?;
-        let binary_path = format!("{version_dir}/postgrestools");
+        let binary_path = format!("{version_dir}/postgres-language-server");
 
-        if !fs::metadata(&binary_path).map_or(false, |stat| stat.is_file()) {
+        if !fs::metadata(&binary_path).is_ok_and(|stat| stat.is_file()) {
             zed::set_language_server_installation_status(
                 language_server_id,
                 &zed::LanguageServerInstallationStatus::Downloading,


### PR DESCRIPTION
Starting with `0.16.0`, we are (finally) renaming the project to `postgres-language-server`. This PR updates the extension to use the new name. We are dual-publishing for a while to not break the users workflow, so no hurry.

I was not sure about some of the changes, would love a review!

Release Notes: https://github.com/supabase-community/postgres-language-server/releases/tag/0.16.0
