### PR TITLE
fix windows os identifier to match new release binary scheme

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "postgres-language-server"
 name = "Postgres Language Server"
-version = "0.1.0"
+version = "0.1.1"
 schema_version = 1
 authors = ["jeffreyguenther"]
 description = "Postgres Language Server"

--- a/src/postgres_language_server.rs
+++ b/src/postgres_language_server.rs
@@ -58,7 +58,13 @@ impl PostgresLanguageServerExtension {
         let version_dir = format!("postgres-language-server-{}", release.version);
         fs::create_dir_all(&version_dir)
             .map_err(|err| format!("failed to create directory '{version_dir}': {err}"))?;
-        let binary_path = format!("{version_dir}/postgres-language-server");
+        let binary_path = format!(
+            "{version_dir}/postgres-language-server{suffix}",
+            suffix = match platform {
+                zed::Os::Windows => ".exe",
+                _ => "",
+            }
+        );
 
         if !fs::metadata(&binary_path).is_ok_and(|stat| stat.is_file()) {
             zed::set_language_server_installation_status(

--- a/src/postgres_language_server.rs
+++ b/src/postgres_language_server.rs
@@ -45,7 +45,7 @@ impl PostgresLanguageServerExtension {
             os = match platform {
                 zed::Os::Mac => "apple-darwin",
                 zed::Os::Linux => "unknown-linux-gnu",
-                zed::Os::Windows => "pc-windows-msvc",
+                zed::Os::Windows => "pc-windows-msvc.exe",
             }
         );
 


### PR DESCRIPTION
https://github.com/supabase-community/postgres-language-server/releases/tag/0.20.0

starting from 0.20.0 it looks like the postgres-language-server devs added a .exe file extension all the windows release binaries, causing the extension to throw an error:
`from extension "Postgres Language Server" version 0.0.1: no asset found matching "postgrestools_x86_64-pc-windows-msvc"`

tested this change on my zed install on windows as a dev extension and works fine now.

Closes #22