### PR TITLE
Fix Windows install: match upstream .exe asset name (#22)

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "postgres-language-server"
 name = "Postgres Language Server"
-version = "0.1.0"
+version = "0.1.1"
 schema_version = 1
 authors = ["jeffreyguenther"]
 description = "Postgres Language Server"

--- a/src/postgres_language_server.rs
+++ b/src/postgres_language_server.rs
@@ -36,7 +36,7 @@ impl PostgresLanguageServerExtension {
 
         let (platform, arch) = zed::current_platform();
         let asset_name = format!(
-            "postgres-language-server_{arch}-{os}",
+            "postgres-language-server_{arch}-{os}{ext}",
             arch = match arch {
                 zed::Architecture::Aarch64 => "aarch64",
                 zed::Architecture::X86 => "x86",
@@ -46,6 +46,12 @@ impl PostgresLanguageServerExtension {
                 zed::Os::Mac => "apple-darwin",
                 zed::Os::Linux => "unknown-linux-gnu",
                 zed::Os::Windows => "pc-windows-msvc",
+            },
+            // Upstream names the Windows asset with a `.exe` suffix; other
+            // platforms have no extension.
+            ext = match platform {
+                zed::Os::Windows => ".exe",
+                _ => "",
             }
         );
 
@@ -58,7 +64,13 @@ impl PostgresLanguageServerExtension {
         let version_dir = format!("postgres-language-server-{}", release.version);
         fs::create_dir_all(&version_dir)
             .map_err(|err| format!("failed to create directory '{version_dir}': {err}"))?;
-        let binary_path = format!("{version_dir}/postgres-language-server");
+        let binary_path = format!(
+            "{version_dir}/postgres-language-server{suffix}",
+            suffix = match platform {
+                zed::Os::Windows => ".exe",
+                _ => "",
+            }
+        );
 
         if !fs::metadata(&binary_path).is_ok_and(|stat| stat.is_file()) {
             zed::set_language_server_installation_status(


### PR DESCRIPTION
Fix Windows install: match upstream .exe asset name

The upstream postgres-language-server releases name their Windows
binaries with a `.exe` suffix (e.g.
postgres-language-server_x86_64-pc-windows-msvc.exe), while macOS and
Linux assets have no extension. The extension only ever looked for the
extension-less name, so on Windows no asset matched and installation
failed with "no asset found matching ...".

Append `.exe` to both the asset name and the downloaded binary path on
Windows. Bump extension version to 0.1.1.

Fixes #22
